### PR TITLE
Check for error after running ApplyPlanPatches

### DIFF
--- a/cmd/out/out.go
+++ b/cmd/out/out.go
@@ -67,6 +67,10 @@ func main() {
 	stateDir := outrunner.NewStateDir(bblStateDir)
 
 	err = stateDir.ApplyPlanPatches(req.Params.PlanPatches)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "failed to apply plan patches: %s\n", err)
+		os.Exit(1)
+	}
 
 	bblError := outrunner.RunBBL(name, stateDir, req.Params.Command, outrunner.AppendSourceFlags(req.Params.Args, req.Source))
 	if bblError != nil {


### PR DESCRIPTION
The existing code doesn't fail if the plan patch couldn't be found. This PR fixes that.
